### PR TITLE
Update color_picker.dart

### DIFF
--- a/lib/src/color/color_picker.dart
+++ b/lib/src/color/color_picker.dart
@@ -180,7 +180,7 @@ class _ColorPickerState extends State<ColorPicker>
 
     Animation animation;
     animation =
-        new Tween(begin: 0, end: _lastColorList.length).animate(controller)
+        new Tween(begin: 0.0, end: _lastColorList.length).animate(controller)
           ..addListener(() {
             int position =
                 (animation.value * _lastColorList.length / 10).ceil();


### PR DESCRIPTION
Fixed int/double bug.

`The following assertion was thrown while notifying listeners for AnimationController: type 'double' is not a subtype of type 'int' where double is from dart:core int is from dart:core`