### PR TITLE
Corrects package name where asset is loaded from

### DIFF
--- a/lib/src/color/color_picker.dart
+++ b/lib/src/color/color_picker.dart
@@ -295,7 +295,7 @@ class _ColorPickerState extends State<ColorPicker>
                         color: new Color(0x00000000),
                         child: new Image.asset(
                           "res/images/placer.png",
-                          package: "material_color_picker",
+                          package: "material_pickers",
                           width: _frameWidth,
                         ),
                       ),


### PR DESCRIPTION
Flutter was failing to load the placer.png image as the package name was incorrect.
