### PR TITLE
Adds override for barrierLabel getter that is required in the newest flutter master channel builds

### DIFF
--- a/lib/src/color/dropdown.dart
+++ b/lib/src/color/dropdown.dart
@@ -59,6 +59,9 @@ class _WidgetDropdownRoute<T> extends PopupRoute<T> {
   @override
   Duration get transitionDuration => const Duration(milliseconds: 200);
 
+  @override
+  String get barrierLabel => "Dismiss";
+
   void _dismiss() {
     navigator?.removeRoute(this);
   }

--- a/lib/src/picker.dart
+++ b/lib/src/picker.dart
@@ -62,6 +62,9 @@ class _WidgetDropdownRoute<T> extends PopupRoute<T> {
   @override
   Duration get transitionDuration => const Duration(milliseconds: 200);
 
+  @override
+  String get barrierLabel => "Dismiss";
+
   void _dismiss() {
     navigator?.removeRoute(this);
   }


### PR DESCRIPTION
barrierLabel is a string that is read out when it receives focus in
accessibility mode.  I'm not clear on how to test this.  However,
"Dismiss" seems like an appropriate message, and it now compiles and
runs in standard (non-accessibility) mode, whereas it was failing to
compile previously.